### PR TITLE
Allow ID and username instead of just mention for commands

### DIFF
--- a/src/commands/getRep.ts
+++ b/src/commands/getRep.ts
@@ -8,7 +8,24 @@ export const command = new Command({
     aliases: ['getRep'],
     description: 'Get Rep Points',
     command: async (message: Message): Promise<void> => {
-        const member = message.mentions.members!.first() ? message.mentions.members!.first() : message.member;
+        let member = message.mentions.members!.first() ? message.mentions.members!.first() : undefined;
+        if (!member) {
+            const args = message.content.split(' ');
+            args.shift();
+            if (args.length >= 1) {
+                const guild = await message.guild!.fetch();
+                if (!isNaN(Number(args[0]))) {
+                    member = guild.members.get(args[0]);
+                    member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase()) : member;
+                    member = !member ? message.member! : member;
+                } else {
+                    member = guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase());
+                    member = !member ? message.member! : member;
+                }
+            } else {
+                member = message.member!;
+            }
+        }
         const repository = database.getRepository(RepEntity);
         const found = await repository.findOne({ id: member!.id });
 

--- a/src/commands/getRep.ts
+++ b/src/commands/getRep.ts
@@ -3,29 +3,16 @@ import { Message } from 'discord.js';
 import { RepEntity } from '../entities/Rep';
 import { database } from '../index';
 import { Command } from '../utils/commandHandler';
+import { resolveMemberWithNameSpaces } from '../utils/resolvers';
 
 export const command = new Command({
     aliases: ['getRep'],
     description: 'Get Rep Points',
     command: async (message: Message): Promise<void> => {
         let member = message.mentions.members!.first() ? message.mentions.members!.first() : undefined;
-        if (!member) {
-            const args = message.content.split(' ');
-            args.shift();
-            if (args.length >= 1) {
-                const guild = await message.guild!.fetch();
-                if (!isNaN(Number(args[0]))) {
-                    member = guild.members.get(args[0]);
-                    member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase()) : member;
-                    member = !member ? message.member! : member;
-                } else {
-                    member = guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase());
-                    member = !member ? message.member! : member;
-                }
-            } else {
-                member = message.member!;
-            }
-        }
+        member = !member ? await resolveMemberWithNameSpaces(message) : member;
+        member = !member ? message.member! : member;
+
         const repository = database.getRepository(RepEntity);
         const found = await repository.findOne({ id: member!.id });
 

--- a/src/commands/removeRep.ts
+++ b/src/commands/removeRep.ts
@@ -3,7 +3,7 @@ import { GuildMember, Message } from 'discord.js';
 import { RepEntity } from '../entities/Rep';
 import { database } from '../index';
 import { Command } from '../utils/commandHandler';
-import { resolveMemberWithoutNameSpaces } from '../utils/resolvers';
+import { resolveMember } from '../utils/resolvers';
 
 export const command = new Command({
     aliases: ['removerep'],
@@ -16,7 +16,7 @@ export const command = new Command({
         }
 
         let member: GuildMember | undefined = message.mentions.members!.first()!;
-        member = !member ? await resolveMemberWithoutNameSpaces(message) : member;
+        member = !member ? await resolveMember(message) : member;
 
         const amount = parseInt(message.content.split(' ')[2]);
 

--- a/src/commands/removeRep.ts
+++ b/src/commands/removeRep.ts
@@ -3,6 +3,7 @@ import { GuildMember, Message } from 'discord.js';
 import { RepEntity } from '../entities/Rep';
 import { database } from '../index';
 import { Command } from '../utils/commandHandler';
+import { resolveMemberWithoutNameSpaces } from '../utils/resolvers';
 
 export const command = new Command({
     aliases: ['removerep'],
@@ -15,19 +16,8 @@ export const command = new Command({
         }
 
         let member: GuildMember | undefined = message.mentions.members!.first()!;
-        if (!member) {
-            const args = message.content.split(' ');
-            args.shift();
-            if (args.length >= 1) {
-                const guild = await message.guild!.fetch();
-                if (!isNaN(Number(args[0]))) {
-                    member = guild.members.get(args[0]);
-                    member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args[0].toLowerCase()) : member;
-                } else {
-                    member = guild.members.find(m => m.displayName.toLowerCase() === args[0].toLowerCase());
-                }
-            }
-        }
+        member = !member ? await resolveMemberWithoutNameSpaces(message) : member;
+
         const amount = parseInt(message.content.split(' ')[2]);
 
         if (!member) {

--- a/src/commands/removeRep.ts
+++ b/src/commands/removeRep.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { GuildMember, Message } from 'discord.js';
 
 import { RepEntity } from '../entities/Rep';
 import { database } from '../index';
@@ -14,7 +14,20 @@ export const command = new Command({
             return;
         }
 
-        const member = message.mentions.members!.first()!;
+        let member: GuildMember | undefined = message.mentions.members!.first()!;
+        if (!member) {
+            const args = message.content.split(' ');
+            args.shift();
+            if (args.length >= 1) {
+                const guild = await message.guild!.fetch();
+                if (!isNaN(Number(args[0]))) {
+                    member = guild.members.get(args[0]);
+                    member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args[0].toLowerCase()) : member;
+                } else {
+                    member = guild.members.find(m => m.displayName.toLowerCase() === args[0].toLowerCase());
+                }
+            }
+        }
         const amount = parseInt(message.content.split(' ')[2]);
 
         if (!member) {

--- a/src/commands/rep.ts
+++ b/src/commands/rep.ts
@@ -43,8 +43,22 @@ export const command = new Command({
     aliases: ['rep'],
     description: 'Give rep points to someone',
     command: async (message: Message): Promise<void> => {
-        const member = message.mentions.members!.first()!;
-
+        let member: GuildMember | undefined = message.mentions.members!.first()!;
+        if (!member) {
+            const args = message.content.split(' ');
+            args.shift();
+            if (args.length >= 1) {
+                const guild = await message.guild!.fetch();
+                if (!isNaN(Number(args[0]))) {
+                    member = guild.members.get(args[0]);
+                    member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase()) : member;
+                    member = !member ? message.member! : member;
+                } else {
+                    member = guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase());
+                    member = !member ? message.member! : member;
+                }
+            }
+        }
         if (!member) {
             message.channel.send(`:x: You must specify a member to give rep to!`);
             return;

--- a/src/commands/rep.ts
+++ b/src/commands/rep.ts
@@ -4,6 +4,7 @@ import { RepEntity } from '../entities/Rep';
 import { RepCooldownEntity } from '../entities/RepCooldown';
 import { database } from '../index';
 import { Command } from '../utils/commandHandler';
+import { resolveMemberWithNameSpaces } from '../utils/resolvers';
 
 const calcCooldown = async (member: GuildMember): Promise<number> => {
     const repository = database.getRepository(RepCooldownEntity);
@@ -44,21 +45,8 @@ export const command = new Command({
     description: 'Give rep points to someone',
     command: async (message: Message): Promise<void> => {
         let member: GuildMember | undefined = message.mentions.members!.first()!;
-        if (!member) {
-            const args = message.content.split(' ');
-            args.shift();
-            if (args.length >= 1) {
-                const guild = await message.guild!.fetch();
-                if (!isNaN(Number(args[0]))) {
-                    member = guild.members.get(args[0]);
-                    member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase()) : member;
-                    member = !member ? message.member! : member;
-                } else {
-                    member = guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase());
-                    member = !member ? message.member! : member;
-                }
-            }
-        }
+        member = !member ? await resolveMemberWithNameSpaces(message) : member;
+
         if (!member) {
             message.channel.send(`:x: You must specify a member to give rep to!`);
             return;

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -1,0 +1,35 @@
+import { GuildMember, Message } from 'discord.js';
+
+export const resolveMemberWithNameSpaces = async (message: Message): Promise<GuildMember | undefined> => {
+    let member: GuildMember | undefined;
+    const args = message.content.split(' ');
+    args.shift();
+    if (args.length >= 1) {
+        const guild = await message.guild!.fetch();
+        if (!isNaN(Number(args[0]))) {
+            member = guild.members.get(args[0]);
+            member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase()) : member;
+        } else {
+            member = guild.members.find(m => m.displayName.toLowerCase() === args.join(' ').toLowerCase());
+        }
+    } else {
+        member = undefined;
+    }
+    return member;
+};
+
+export const resolveMemberWithoutNameSpaces = async (message: Message): Promise<GuildMember | undefined> => {
+    let member: GuildMember | undefined;
+    const args = message.content.split(' ');
+    args.shift();
+    if (args.length >= 1) {
+        const guild = await message.guild!.fetch();
+        if (!isNaN(Number(args[0]))) {
+            member = guild.members.get(args[0]);
+            member = !member ? guild.members.find(m => m.displayName.toLowerCase() === args[0].toLowerCase()) : member;
+        } else {
+            member = guild.members.find(m => m.displayName.toLowerCase() === args[0].toLowerCase());
+        }
+    }
+    return member;
+};

--- a/src/utils/resolvers.ts
+++ b/src/utils/resolvers.ts
@@ -18,7 +18,7 @@ export const resolveMemberWithNameSpaces = async (message: Message): Promise<Gui
     return member;
 };
 
-export const resolveMemberWithoutNameSpaces = async (message: Message): Promise<GuildMember | undefined> => {
+export const resolveMember = async (message: Message): Promise<GuildMember | undefined> => {
     let member: GuildMember | undefined;
     const args = message.content.split(' ');
     args.shift();


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Imlements #24. Allows using an ID or a username instead of mentioning a user for t!getrep, t!removerep and t!rep.
Example: 
- t!rep 191146743163781120
- t!getrep LapinoLapidus

Does this close any currently open issues?
------------------------------------------

#24 

Any relevant logs, error output, etc?
-------------------------------------

Nope.

Any other comments?
-------------------
Nope.

Where has this been tested?
---------------------------
Local instance