### PR TITLE
Adds Feature: Tagged Messages

### DIFF
--- a/src/commands/tag.ts
+++ b/src/commands/tag.ts
@@ -1,0 +1,81 @@
+import { Message } from 'discord.js';
+
+import { TagEntity } from '../entities/Tag';
+import { database } from '../index';
+import { Command } from '../utils/commandHandler';
+
+const create = async (message: Message): Promise<Message> => {
+    const split = message.content.split(' ').slice(2);
+    const name = split[0];
+    const content = split.slice(1).join(' ');
+
+    if (!name) return message.channel.send(`:x: Please provide a valid name`);
+    if (!content) return message.channel.send(`:x: Please provide content`);
+
+    const repository = database.getRepository(TagEntity);
+    if ((await repository.findOne({ name })) != undefined) {
+        return message.channel.send(`:x: A tag with the name **${name}** already exists`);
+    }
+
+    await repository.insert({
+        name,
+        content,
+        author: message.member!.id,
+    });
+
+    return message.channel.send(`:ballot_box_with_check: Successfully created a tag with the name **${name}**`);
+};
+
+const edit = async (message: Message): Promise<Message> => {
+    const split = message.content.split(' ').slice(2);
+    const name = split[0];
+    const content = split.slice(1).join(' ');
+
+    if (!name) return message.channel.send(`:x: Please provide a name`);
+    if (!content) return message.channel.send(`:x: Please provide content`);
+
+    const repository = database.getRepository(TagEntity);
+    const found = await repository.findOne({ name });
+    if (found == undefined) {
+        return message.channel.send(`:x: No tag with the name **${name}** exists`);
+    }
+
+    found.content = content;
+
+    await repository.save(found);
+
+    return message.channel.send(`:ballot_box_with_check: Successfully edited the tag **${name}**`);
+};
+
+const del = async (message: Message): Promise<Message> => {
+    const split = message.content.split(' ').slice(2);
+    const name = split[0];
+
+    if (!name) return message.channel.send(`:x: Please provide a name`);
+
+    const repository = database.getRepository(TagEntity);
+    const found = await repository.findOne({ name });
+    if (found == undefined) {
+        return message.channel.send(`:x: No tag with the name **${name}** exists`);
+    }
+
+    await repository.delete(found);
+
+    return message.channel.send(`:ballot_box_with_check: Successfully deleted the tag **${name}**`);
+};
+
+export const command = new Command({
+    description: 'Manage tags (mods+ only)',
+    aliases: ['tag', 'tags'],
+    privelagesRequired: ['MANAGE_MESSAGES'],
+    command: async (message: Message): Promise<void | Message> => {
+        const action = message.content.split(' ')[1];
+
+        if (!action || (action != 'create' && action != 'edit' && action != 'delete'))
+            return message.channel.send(`:x: Please provide a valid action (create, edit, delete)`);
+
+        if (action == 'create') await create(message);
+        if (action == 'edit') await edit(message);
+        if (action == 'delete') await del(message);
+    },
+});

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -10,10 +10,11 @@ import { Filter, FilterHandler } from '../utils/filterHandler';
 import { ModLogManager } from '../utils/modlogManager';
 import { playgroundLinksMessage } from '../utils/playgroundLinks';
 import { pollsMessage } from '../utils/polls';
+import { tagsMessage } from '../utils/tags';
 
 export class PascalClient extends Client {
     commandHandler: CommandHandler = new CommandHandler(this, {
-        prefix: 't!',
+        prefix: 's!',
         logger: (...message): void => console.log('[BOT]', ...message),
         guildsAllowed: ['508357248330760243'],
     });
@@ -36,6 +37,7 @@ export class PascalClient extends Client {
 
         this.on('message', pollsMessage);
         this.on('message', playgroundLinksMessage);
+        this.on('message', tagsMessage);
     }
 
     public async start(): Promise<void> {

--- a/src/core/Client.ts
+++ b/src/core/Client.ts
@@ -14,7 +14,7 @@ import { tagsMessage } from '../utils/tags';
 
 export class PascalClient extends Client {
     commandHandler: CommandHandler = new CommandHandler(this, {
-        prefix: 's!',
+        prefix: 't!',
         logger: (...message): void => console.log('[BOT]', ...message),
         guildsAllowed: ['508357248330760243'],
     });

--- a/src/core/Database.ts
+++ b/src/core/Database.ts
@@ -5,22 +5,25 @@ import { HistoryEntity } from '../entities/History';
 import { ReminderEntity } from '../entities/Reminder';
 import { RepEntity } from '../entities/Rep';
 import { RepCooldownEntity } from '../entities/RepCooldown';
+import { TagEntity } from '../entities/Tag';
 
 export class Database extends Connection {
     public constructor() {
+        const entities = [RepEntity, RepCooldownEntity, ReminderEntity, HistoryEntity, TagEntity];
+
         if (process.env.NODE_ENV != 'production') {
             super({
                 type: 'sqlite',
                 database: join(__dirname, '..', '..', 'database.sqlite'),
                 logging: true,
-                entities: [RepEntity, RepCooldownEntity, ReminderEntity, HistoryEntity],
+                entities,
                 synchronize: true,
             });
         } else {
             super({
                 type: 'postgres',
                 logging: true,
-                entities: [RepEntity, RepCooldownEntity, ReminderEntity, HistoryEntity],
+                entities,
                 synchronize: true,
                 ssl: true,
                 url: process.env.DATABASE_URL!,

--- a/src/entities/Tag.ts
+++ b/src/entities/Tag.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('tags')
+export class TagEntity {
+    @PrimaryColumn()
+    name: string;
+
+    @Column()
+    content: string;
+
+    @Column()
+    author: string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -32,3 +32,7 @@ export const LOGGING = {
         info: '#005791',
     },
 };
+
+export const TAGS = {
+    prefix: '?',
+};

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,0 +1,17 @@
+import { Message } from 'discord.js';
+
+import { TagEntity } from '../entities/Tag';
+import { database } from '../index';
+import { TAGS } from './constants';
+
+export const tagsMessage = async (message: Message): Promise<void> => {
+    if (!message.content.startsWith(TAGS.prefix)) return;
+
+    const tag = message.content.split(' ')[0].replace(TAGS.prefix, '');
+    const repository = database.getRepository(TagEntity);
+    const found = await repository.findOne({ name: tag });
+
+    if (!found) return;
+
+    await message.channel.send(found.content);
+};


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Tagged messages allow us to avoid repeating common text content by refactoring it into dynamically allocated command namespaces.
- Adds three new commands, `t!tags <create|edit|delete>` 

Where has this been tested?
---------------------------
- Staging Bot Account
- Private Staff Test Channels
