### PR TITLE
fix: rep command shouldn't care about the week day

### DIFF
--- a/src/commands/rep.ts
+++ b/src/commands/rep.ts
@@ -24,7 +24,7 @@ const calcCooldown = async (member: GuildMember): Promise<number> => {
         const updatedDate = new Date(found.updated);
         const nowDate = new Date();
 
-        if (updatedDate.getUTCDay() != nowDate.getUTCDay()) {
+        if (updatedDate.toDateString() != nowDate.toDateString()) {
             found.left = 3;
         }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
getUTCDay returns the day of the week, so if I wait 7 days before trying to give rep again, the rep won't be reset.

toDateString returns a string describing the current *date*, so while it won't reset with the UTC day, it will at least allow a reset every 24 hours.

You could preserve the intended behavior by constructing a date string by using the getUTC* functions, but that was more than I have time for right now.

Where has this been tested?
--------------------------

nowhere
