### PR TITLE
fix: Rep command should respect nicknames

### DIFF
--- a/src/commands/rep.ts
+++ b/src/commands/rep.ts
@@ -82,7 +82,7 @@ export const command = new Command({
             await repository.save(found);
         }
 
-        message.channel.send(`:ballot_box_with_check: Successfully sent rep to **${member.user.username}** (**${cooldown}** remaining today)`);
+        message.channel.send(`:ballot_box_with_check: Successfully sent rep to **${member.displayName}** (**${cooldown}** remaining today)`);
 
         addRepHistory(message.member!, member, message);
     },


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This respects user nicknames instead of always displaying their user name when `t!rep` is used.

Where has this been tested?
---------------------------
Nowhere, not even sure if it compiles, but the property seems to exist - https://discord.js.org/#/docs/main/stable/class/GuildMember?scrollTo=displayName
