### PR TITLE
Allow `!ts` to be run on a codeblock in the message it is run from

### DIFF
--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -2,12 +2,24 @@ import { command, Module } from 'cookiecord';
 import { Message, TextChannel } from 'discord.js';
 import { twoslasher } from '@typescript/twoslash';
 import { findCodeblockFromChannel } from '../util/findCodeblockFromChannel';
+import { send } from 'process';
 
 const CODEBLOCK = '```';
 
 export class TwoslashModule extends Module {
 	@command({ single: true })
-	async ts(msg: Message, symbol: string) {
+	async ts(msg: Message, content: string) {
+		const match = /^[_$a-zA-Z][_$0-9a-zA-Z]*/.exec(content);
+
+		if (!match) {
+			msg.channel.send(
+				'You need to give me a valid symbol name to look for!',
+			);
+			return;
+		}
+
+		const symbol = match[0];
+
 		const code = await findCodeblockFromChannel(msg.channel as TextChannel);
 
 		if (!code)

--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -2,7 +2,6 @@ import { command, Module } from 'cookiecord';
 import { Message, TextChannel } from 'discord.js';
 import { twoslasher } from '@typescript/twoslash';
 import { findCodeblockFromChannel } from '../util/findCodeblockFromChannel';
-import { send } from 'process';
 
 const CODEBLOCK = '```';
 
@@ -50,7 +49,7 @@ export class TwoslashModule extends Module {
 
 		if (!code)
 			return msg.channel.send(
-				`:warning: cou  ld not find any TypeScript codeblocks in the past 10 messages`,
+				`:warning: could not find any TypeScript codeblocks in the past 10 messages`,
 			);
 
 		const ret = twoslasher(code, 'ts', {

--- a/src/util/findCodeblockFromChannel.ts
+++ b/src/util/findCodeblockFromChannel.ts
@@ -3,7 +3,7 @@ import { TextChannel } from 'discord.js';
 export async function findCodeblockFromChannel(
 	channel: TextChannel,
 	ignoreLatest?: boolean,
-) {
+): Promise<string | undefined> {
 	const CODEBLOCK_REGEX = /```(?:ts|typescript)?\n([\s\S]+)```/gm;
 
 	const msgs = (await channel.messages.fetch({ limit: 10 }))


### PR DESCRIPTION
This just adds parsing to the `!ts` command so it only searches for valid symbols. Also included: a typo fix, and a more honest type for `findCodeblockFromChannel`