### PR TITLE
feat: Make !twoslash look for playground links

### DIFF
--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -8,7 +8,10 @@ import {
 import { Message, MessageEmbed, TextChannel } from 'discord.js';
 import { compressToEncodedURIComponent } from 'lz-string';
 import { TS_BLUE } from '../env';
-import { findCodeblockFromChannel } from '../util/findCodeblockFromChannel';
+import {
+	findCodeblockFromChannel,
+	PLAYGROUND_REGEX,
+} from '../util/findCodeblockFromChannel';
 
 export class PlaygroundModule extends Module {
 	constructor(client: CookiecordClient) {
@@ -16,7 +19,6 @@ export class PlaygroundModule extends Module {
 	}
 
 	private editedLongLink = new Map<string, Message>();
-	private PG_REGEX = /https?:\/\/(?:www\.)?typescriptlang\.org\/(play|dev\/bug-workbench)(?:\/index\.html)?\/?\??(?:\w+=[^\s#&]+)?(?:\&\w+=[^\s#&]+)*#code\/[\w-+_]+={0,4}/gi;
 
 	@command({ aliases: ['pg', 'playg'], single: true })
 	async playground(msg: Message, @optional code?: string) {
@@ -41,7 +43,7 @@ export class PlaygroundModule extends Module {
 
 	@listener({ event: 'message' })
 	async onLongPGLink(msg: Message) {
-		const exec = this.PG_REGEX.exec(msg.content);
+		const exec = PLAYGROUND_REGEX.exec(msg.content);
 		if (msg.author.bot || !exec || !exec[0]) return;
 		const embed = new MessageEmbed()
 			.setColor(TS_BLUE)
@@ -64,7 +66,7 @@ export class PlaygroundModule extends Module {
 	@listener({ event: 'messageUpdate' })
 	async onLongFix(_oldMsg: Message, msg: Message) {
 		if (msg.partial) await msg.fetch();
-		const exec = this.PG_REGEX.exec(msg.content);
+		const exec = PLAYGROUND_REGEX.exec(msg.content);
 		if (msg.author.bot || !this.editedLongLink.has(msg.id) || exec) return;
 		const botMsg = this.editedLongLink.get(msg.id);
 		await botMsg?.edit('');

--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -1,14 +1,14 @@
 import { command, Module } from 'cookiecord';
 import { Message, TextChannel } from 'discord.js';
 import { twoslasher } from '@typescript/twoslash';
-import { findCodeblockFromChannel } from '../util/findCodeblockFromChannel';
+import { findCodeFromChannel } from '../util/findCodeblockFromChannel';
 
 const CODEBLOCK = '```';
 
 export class TwoslashModule extends Module {
 	@command({ single: true })
 	async ts(msg: Message, symbol: string) {
-		const code = await findCodeblockFromChannel(msg.channel as TextChannel);
+		const code = await findCodeFromChannel(msg.channel as TextChannel);
 
 		if (!code)
 			return msg.channel.send(
@@ -34,11 +34,11 @@ export class TwoslashModule extends Module {
 
 	@command()
 	async twoslash(msg: Message) {
-		const code = await findCodeblockFromChannel(msg.channel as TextChannel);
+		const code = await findCodeFromChannel(msg.channel as TextChannel);
 
 		if (!code)
 			return msg.channel.send(
-				`:warning: cou  ld not find any TypeScript codeblocks in the past 10 messages`,
+				`:warning: could not find any TypeScript codeblocks in the past 10 messages`,
 			);
 
 		const ret = twoslasher(code, 'ts', {

--- a/src/util/findCodeblockFromChannel.ts
+++ b/src/util/findCodeblockFromChannel.ts
@@ -1,11 +1,14 @@
 import { TextChannel } from 'discord.js';
+import { decompressFromEncodedURIComponent } from 'lz-string';
+
+const CODEBLOCK_REGEX = /```(?:ts|typescript)?\n([\s\S]+)```/;
+
+export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?typescriptlang\.org\/(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?\??(?:\w+=[^\s#&]+)?(?:\&\w+=[^\s#&]+)*#code\/([\w-+_]+={0,4})/;
 
 export async function findCodeblockFromChannel(
 	channel: TextChannel,
 	ignoreLatest?: boolean,
 ) {
-	const CODEBLOCK_REGEX = /```(?:ts|typescript)?\n([\s\S]+)```/gm;
-
 	const msgs = (await channel.messages.fetch({ limit: 10 }))
 		.array()
 		.filter(msg => msg.author.bot !== true);
@@ -16,4 +19,26 @@ export async function findCodeblockFromChannel(
 		.map(m => CODEBLOCK_REGEX.exec(m.content))
 		.map(x => (x ? x[1] : ''))
 		.filter(x => x !== '')[0];
+}
+
+// Two possibilities:
+// 1: Normal code block annotated with ts from a non-bot
+// 2: Link to TS playground. This can be either from a bot or a normal user
+//    since we shorten playground links on their own and delete the message.
+export async function findCodeFromChannel(channel: TextChannel) {
+	const msgs = (await channel.messages.fetch({ limit: 10 })).array();
+
+	for (const { author, content } of msgs) {
+		if (!author.bot) {
+			const match = content.match(CODEBLOCK_REGEX);
+			if (match && match[1].length) {
+				return match[1];
+			}
+		}
+
+		const match = content.match(PLAYGROUND_REGEX);
+		if (match) {
+			return decompressFromEncodedURIComponent(match[1]);
+		}
+	}
 }

--- a/src/util/findCodeblockFromChannel.ts
+++ b/src/util/findCodeblockFromChannel.ts
@@ -13,7 +13,7 @@ export async function findCodeblockFromChannel(
 		.array()
 		.filter(msg => msg.author.bot !== true);
 
-	if (ignoreLatest) msgs.pop();
+	if (ignoreLatest) msgs.shift();
 
 	return msgs
 		.map(m => CODEBLOCK_REGEX.exec(m.content))

--- a/src/util/findCodeblockFromChannel.ts
+++ b/src/util/findCodeblockFromChannel.ts
@@ -28,7 +28,7 @@ export async function findCodeblockFromChannel(
 export async function findCodeFromChannel(channel: TextChannel) {
 	const msgs = (await channel.messages.fetch({ limit: 10 })).array();
 
-	for (const { author, content } of msgs) {
+	for (const { author, content, embeds } of msgs) {
 		if (!author.bot) {
 			const match = content.match(CODEBLOCK_REGEX);
 			if (match && match[1].length) {
@@ -39,6 +39,13 @@ export async function findCodeFromChannel(channel: TextChannel) {
 		const match = content.match(PLAYGROUND_REGEX);
 		if (match) {
 			return decompressFromEncodedURIComponent(match[1]);
+		}
+
+		for (const embed of embeds) {
+			const match = embed.url?.match(PLAYGROUND_REGEX);
+			if (match) {
+				return decompressFromEncodedURIComponent(match[1]);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Also fixed a typo and removed unnecessary flags on regular expressions. `m` only affects the behavior of `^` and `$`... which weren't used, and `g` causes the regex to store state about where the match was made... which we don't care about.
