### PR TITLE
feat: Recognize standalone twoslash code blocks

### DIFF
--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -1,4 +1,4 @@
-import { command, Module } from 'cookiecord';
+import { command, Module, listener } from 'cookiecord';
 import { Message, TextChannel } from 'discord.js';
 import { twoslasher } from '@typescript/twoslash';
 import { findCodeFromChannel } from '../util/findCodeblockFromChannel';
@@ -41,6 +41,19 @@ export class TwoslashModule extends Module {
 				`:warning: could not find any TypeScript codeblocks in the past 10 messages`,
 			);
 
+		return this.twoslashBlock(msg, code);
+	}
+
+	@listener({ event: 'message' })
+	async onTwoslashCodeBlock(msg: Message) {
+		const match = msg.content.match(/^```ts twoslash\n([\s\S]+)```$/im);
+		if (!msg.author.bot && match) {
+			await this.twoslashBlock(msg, match[1]);
+			await msg.delete();
+		}
+	}
+
+	private async twoslashBlock(msg: Message, code: string) {
 		const ret = twoslasher(code, 'ts', {
 			defaultOptions: {
 				noErrorValidation: true,


### PR DESCRIPTION
This adds a listener which looks for messages which contain only a twoslash codeblock and automatically replaces it with a block with twoslash run on it.

````
```ts twoslash
console.log(1)
```
````

![image](https://user-images.githubusercontent.com/19329837/91609535-d20f2300-e934-11ea-95d7-4a2d6aeec716.png)

![image](https://user-images.githubusercontent.com/19329837/91609546-d76c6d80-e934-11ea-8225-0eac1914f646.png)
