### PR TITLE
fix: Hats in twoslash errors should be commented

### DIFF
--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -105,9 +105,11 @@ export class TwoslashModule extends Module {
 					linkWithHats += ' '.repeat(spaceBefore);
 					linkWithHats += '^'.repeat(e.length || 0);
 				});
+
 				if (linkWithHats.length > 0) {
 					resultLines.push('//' + linkWithHats.substr(2));
 				}
+
 				resultLines.push(...errors);
 			}
 

--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -105,7 +105,9 @@ export class TwoslashModule extends Module {
 					linkWithHats += ' '.repeat(spaceBefore);
 					linkWithHats += '^'.repeat(e.length || 0);
 				});
-				resultLines.push(linkWithHats);
+				if (linkWithHats.length > 0) {
+					resultLines.push('//' + linkWithHats.substr(2));
+				}
 				resultLines.push(...errors);
 			}
 


### PR DESCRIPTION
Also fixes the bug where errors which took up the whole line would result in an empty line being included.

````
```ts twoslash
foo
```
````

followed by

````
```ts twoslash
declare const x: { a?: { b: boolean, c: string }}

if (x.a!.b)
    x.a.c + foo
```
````

now produces:

![image](https://user-images.githubusercontent.com/19329837/94996972-32613800-0565-11eb-8f75-3a094a9f7988.png)
