### PR TITLE
fix: Thanks regex needs \b on both sides

### DIFF
--- a/src/modules/rep.ts
+++ b/src/modules/rep.ts
@@ -20,7 +20,7 @@ export class RepModule extends Module {
 	MAX_REP = 3;
 
 	// all messages have to be fully lowercase
-	THANKS_REGEX = /(?:thanks|thx|cheers|thanx|ty|tks|tkx)\b/i;
+	THANKS_REGEX = /\b(?:thanks|thx|cheers|thanx|ty|tks|tkx)\b/i;
 
 	async getOrMakeUser(user: User) {
 		let ru = await RepUser.findOne(


### PR DESCRIPTION
This will fix the bot triggering on `community` as a thank you message.

![image](https://user-images.githubusercontent.com/19329837/94997363-cf24d500-0567-11eb-8d29-8c635742ca4e.png)

![image](https://user-images.githubusercontent.com/19329837/94997376-e794ef80-0567-11eb-952e-69bd0ae9c49f.png)
