### PR TITLE
Remove incorrect comment

### DIFF
--- a/src/modules/rep.ts
+++ b/src/modules/rep.ts
@@ -19,7 +19,6 @@ export class RepModule extends Module {
 
 	MAX_REP = 3;
 
-	// all messages have to be fully lowercase
 	THANKS_REGEX = /\b(?:thanks|thx|cheers|thanx|ty|tks|tkx)\b/i;
 
 	async getOrMakeUser(user: User) {


### PR DESCRIPTION
This PR removes an incorrect comment regarding a RegEx in the code, which has the potential to mislead and confuse other people studying the code for their own learning purposes.

This comment was leftover from the old "thanks" check, but it doesn't belong there anymore.