### PR TITLE
feat: Support for deleting bot messages

### DIFF
--- a/src/modules/etc.ts
+++ b/src/modules/etc.ts
@@ -4,7 +4,8 @@ import {
 	Module,
 	listener,
 } from 'cookiecord';
-import { Message } from 'discord.js';
+import { Message, MessageReaction, GuildMember } from 'discord.js';
+import { clearMessageOwnership, ownsBotMessage } from '../util/send';
 
 export class EtcModule extends Module {
 	constructor(client: CookiecordClient) {
@@ -38,5 +39,16 @@ export class EtcModule extends Module {
 		await msg.react('✅');
 		await msg.react('❌');
 		await msg.react('🤷');
+	}
+
+	@listener({ event: 'messageReactionAdd' })
+	async onReact(reaction: MessageReaction, member: GuildMember) {
+		if (
+			reaction.emoji.name === '❌' &&
+			ownsBotMessage(reaction.message, member)
+		) {
+			clearMessageOwnership(reaction.message);
+			await reaction.message.delete();
+		}
 	}
 }

--- a/src/modules/etc.ts
+++ b/src/modules/etc.ts
@@ -45,7 +45,7 @@ export class EtcModule extends Module {
 	async onReact(reaction: MessageReaction, member: GuildMember) {
 		if (
 			reaction.emoji.name === '❌' &&
-			ownsBotMessage(reaction.message, member)
+			ownsBotMessage(reaction.message, member.id)
 		) {
 			clearMessageOwnership(reaction.message);
 			await reaction.message.delete();

--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -12,6 +12,7 @@ import {
 	findCodeblockFromChannel,
 	PLAYGROUND_REGEX,
 } from '../util/findCodeblockFromChannel';
+import { addMessageOwnership, sendWithMessageOwnership } from '../util/send';
 
 export class PlaygroundModule extends Module {
 	constructor(client: CookiecordClient) {
@@ -34,7 +35,8 @@ export class PlaygroundModule extends Module {
 				true,
 			);
 			if (!code)
-				return await msg.channel.send(
+				return sendWithMessageOwnership(
+					msg,
 					":warning: couldn't find a codeblock!",
 				);
 		}
@@ -42,7 +44,7 @@ export class PlaygroundModule extends Module {
 			.setURL(PLAYGROUND_BASE + compressToEncodedURIComponent(code))
 			.setTitle('View in Playground')
 			.setColor(TS_BLUE);
-		await msg.channel.send({ embed });
+		await sendWithMessageOwnership(msg, { embed });
 	}
 
 	@listener({ event: 'message' })
@@ -56,8 +58,8 @@ export class PlaygroundModule extends Module {
 			.setURL(exec[0]);
 		if (exec[0] == msg.content) {
 			// Message only contained the link
+			await sendWithMessageOwnership(msg, { embed });
 			msg.delete();
-			await msg.channel.send({ embed });
 		} else {
 			// Message also contained other characters
 			const botMsg = await msg.channel.send(
@@ -65,6 +67,7 @@ export class PlaygroundModule extends Module {
 				{ embed },
 			);
 			this.editedLongLink.set(msg.id, botMsg);
+			addMessageOwnership(botMsg, msg.author);
 		}
 	}
 	@listener({ event: 'messageUpdate' })

--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -2,6 +2,7 @@ import { command, Module, listener } from 'cookiecord';
 import { Message, TextChannel } from 'discord.js';
 import { twoslasher } from '@typescript/twoslash';
 import { findCodeFromChannel } from '../util/findCodeblockFromChannel';
+import { sendWithMessageOwnership } from '../util/send';
 
 const CODEBLOCK = '```';
 
@@ -15,10 +16,10 @@ export class TwoslashModule extends Module {
 		const match = /^[_$a-zA-Z][_$0-9a-zA-Z]*/.exec(content);
 
 		if (!match) {
-			msg.channel.send(
+			return sendWithMessageOwnership(
+				msg,
 				'You need to give me a valid symbol name to look for!',
 			);
-			return;
 		}
 
 		const symbol = match[0];
@@ -26,7 +27,8 @@ export class TwoslashModule extends Module {
 		const code = await findCodeFromChannel(msg.channel as TextChannel);
 
 		if (!code)
-			return msg.channel.send(
+			return sendWithMessageOwnership(
+				msg,
 				`:warning: could not find any TypeScript codeblocks in the past 10 messages`,
 			);
 
@@ -38,11 +40,13 @@ export class TwoslashModule extends Module {
 			i => i.targetString === symbol.trim(),
 		);
 		if (!value)
-			return msg.channel.send(
+			return sendWithMessageOwnership(
+				msg,
 				`:warning: no symbol named \`${symbol}\` in the most recent codeblock`,
 			);
 
-		return msg.channel.send(
+		await sendWithMessageOwnership(
+			msg,
 			`${CODEBLOCK}typescript\n${value.text}${CODEBLOCK}`,
 		);
 	}
@@ -55,7 +59,8 @@ export class TwoslashModule extends Module {
 		const code = await findCodeFromChannel(msg.channel as TextChannel);
 
 		if (!code)
-			return msg.channel.send(
+			return sendWithMessageOwnership(
+				msg,
 				`:warning: could not find any TypeScript codeblocks in the past 10 messages`,
 			);
 
@@ -131,6 +136,9 @@ export class TwoslashModule extends Module {
 		});
 
 		const output = resultLines.join('\n');
-		return msg.channel.send(`${CODEBLOCK}ts\n${output}${CODEBLOCK}\n`);
+		return sendWithMessageOwnership(
+			msg,
+			`${CODEBLOCK}ts\n${output}${CODEBLOCK}\n`,
+		);
 	}
 }

--- a/src/util/send.ts
+++ b/src/util/send.ts
@@ -1,0 +1,27 @@
+import { Message, MessageEmbed, GuildMember } from 'discord.js';
+
+const MAX_TRACKED_MESSAGES = 1000;
+
+const messageIdToMemberId = new Map<string, string>();
+
+export async function sendWithMessageOwnership(
+	message: Message,
+	toSend: string | MessageEmbed,
+) {
+	const sent = await message.channel.send(toSend);
+	messageIdToMemberId.set(sent.id, message.author.id);
+
+	// Without this memory grows unboundedly... very slowly, but better to avoid the issue.
+	if (messageIdToMemberId.size > MAX_TRACKED_MESSAGES) {
+		// Keys returns an iterable in insertion order, so we remove the oldest message from the map.
+		messageIdToMemberId.delete(messageIdToMemberId.keys().next().value);
+	}
+}
+
+export function ownsBotMessage(message: Message, member: GuildMember) {
+	return messageIdToMemberId.get(message.id) === member.id;
+}
+
+export function clearMessageOwnership(message: Message) {
+	messageIdToMemberId.delete(message.id);
+}

--- a/src/util/send.ts
+++ b/src/util/send.ts
@@ -21,8 +21,8 @@ export function addMessageOwnership(message: Message, user: User) {
 	}
 }
 
-export function ownsBotMessage(message: Message, user: User) {
-	return messageToUserId.get(message.id) === user.id;
+export function ownsBotMessage(message: Message, userId: string) {
+	return messageToUserId.get(message.id) === userId;
 }
 
 export function clearMessageOwnership(message: Message) {


### PR DESCRIPTION
This adds support for members who requested a twoslash bot message to delete it without requiring the manage messages permission.