### PR TITLE
Put channels into dormant after 5 minutes if ongoing channel becomes empty

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,7 @@ ASK_COOLDOWN_ROLE=
 
 CHANNEL_NAMES=list,help,channel,names,here,seperated,by,commas
 
-# In milliseconds
+# Following variables are in milliseconds
 DORMANT_CHANNEL_TIMEOUT=
-# In milliseconds
 DORMANT_CHANNEL_LOOP=
-
-# In milliseconds
 ONGOING_EMPTY_TIMEOUT=

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,10 @@ ASK_COOLDOWN_ROLE=
 
 CHANNEL_NAMES=list,help,channel,names,here,seperated,by,commas
 
-# In seconds
+# In milliseconds
 DORMANT_CHANNEL_TIMEOUT=
 # In milliseconds
 DORMANT_CHANNEL_LOOP=
+
+# In milliseconds
+ONGOING_EMPTY_TIMEOUT=

--- a/src/env.ts
+++ b/src/env.ts
@@ -28,9 +28,13 @@ export const trustedRoleId = process.env.TRUSTED_ROLE_ID!;
 export const askHelpChannelId = process.env.ASK_HELP_CHANNEL!;
 
 export const channelNames = process.env.CHANNEL_NAMES!.split(',');
+
 export const dormantChannelTimeout = parseInt(
 	process.env.DORMANT_CHANNEL_TIMEOUT!,
 );
 export const dormantChannelLoop = parseInt(process.env.DORMANT_CHANNEL_LOOP!);
+
+export const ongoingEmptyTimeout = parseInt(process.env.ONGOING_EMPTY_TIMEOUT!);
+
 export const TS_BLUE = '#007ACC';
 export const GREEN = '#77b155';

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -140,9 +140,7 @@ export class HelpChanModule extends Module {
 		)
 			return;
 
-		if (await this.checkEmptyOngoing(msg.channel)) {
-			await this.startEmptyTimeout(msg.channel);
-		}
+		await this.startEmptyTimeout(msg.channel);
 	}
 
 	async moveChannel(channel: TextChannel, category: string) {

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -67,8 +67,7 @@ export class HelpChanModule extends Module {
 		.setDescription(DORMANT_MESSAGE);
 
 	busyChannels: Set<string> = new Set(); // a lock to eliminate race conditions
-	// a lock used to prevent multiple timeouts running on the same channel
-	ongoingEmptyTimeouts: Set<string> = new Set();
+	ongoingEmptyTimeouts: Set<string> = new Set(); // a lock used to prevent multiple timeouts running on the same channel
 
 	private getChannelName(guild: Guild) {
 		const takenChannelNames = guild.channels.cache
@@ -115,7 +114,7 @@ export class HelpChanModule extends Module {
 	async checkEmptyOngoing(channel: TextChannel) {
 		const messages = await channel.messages.fetch();
 
-		return messages.array()[0].author.id === this.client.user?.id;
+		return messages.first()?.author.id === this.client.user?.id;
 	}
 
 	async startEmptyTimeout(channel: TextChannel) {
@@ -309,7 +308,8 @@ export class HelpChanModule extends Module {
 		for (const channel of this.getOngoingChannels()) {
 			const messages = await channel.messages.fetch();
 
-			const diff = Date.now() - messages.array()[0].createdAt.getTime();
+			const diff =
+				Date.now() - (messages.first()?.createdAt.getTime() ?? 0);
 
 			if (diff > dormantChannelTimeout)
 				await this.markChannelAsDormant(channel);


### PR DESCRIPTION
This PR introduces a check for when a message is deleted in a channel, and if the channel's last message was the bot embed, it will start a timeout based on an environment variable. When the timeout completes, it will again check if the channel is empty, and if so it will mark it as dormant.

This PR also cleans up and removes inconsistencies from the dormant check loop.