### PR TITLE
Fix bug in escapeCode re 5 backticks

### DIFF
--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -11,7 +11,7 @@ const CODEBLOCK = '```';
 // bad. It doesn't properly handle escaping back ticks, so we instead insert zero width spaces
 // so that users cannot escape our code block.
 function escapeCode(code: string) {
-	return code.replace(/```/g, '`\u200B`\u200B`');
+	return code.replace(/`(?=`)/g, '`\u200B');
 }
 
 export class TwoslashModule extends Module {


### PR DESCRIPTION
````` was replaced with \`ZWS\`ZWS\`\`\`, which still escaped the code block.
This will replace it with \`ZWS\`ZWS\`ZWS\`ZWS\`