### PR TITLE
fix: Add trash can in addMessageOwnership

### DIFF
--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -12,6 +12,7 @@ import {
 	findCodeblockFromChannel,
 	PLAYGROUND_REGEX,
 } from '../util/findCodeblockFromChannel';
+import { LimitedSizeMap } from '../util/limitedSizeMap';
 import { addMessageOwnership, sendWithMessageOwnership } from '../util/send';
 
 export class PlaygroundModule extends Module {
@@ -19,7 +20,7 @@ export class PlaygroundModule extends Module {
 		super(client);
 	}
 
-	private editedLongLink = new Map<string, Message>();
+	private editedLongLink = new LimitedSizeMap<string, Message>(1000);
 
 	@command({
 		aliases: ['pg', 'playg'],
@@ -67,9 +68,10 @@ export class PlaygroundModule extends Module {
 				{ embed },
 			);
 			this.editedLongLink.set(msg.id, botMsg);
-			addMessageOwnership(botMsg, msg.author);
+			await addMessageOwnership(botMsg, msg.author);
 		}
 	}
+
 	@listener({ event: 'messageUpdate' })
 	async onLongFix(_oldMsg: Message, msg: Message) {
 		if (msg.partial) await msg.fetch();

--- a/src/util/limitedSizeMap.ts
+++ b/src/util/limitedSizeMap.ts
@@ -1,0 +1,22 @@
+/**
+ * A FIFO style limited size map, used to prevent memory from growing unboundedly when tracking messages.
+ */
+export class LimitedSizeMap<K, V> extends Map<K, V> implements Map<K, V> {
+	private _maxSize: number;
+
+	constructor(maxSize: number) {
+		super();
+		this._maxSize = maxSize;
+	}
+
+	set(key: K, val: V) {
+		super.set(key, val);
+
+		if (this.size > this._maxSize) {
+			// Keys returns an iterable in insertion order, so this removes the oldest entry from the map.
+			this.delete(this.keys().next().value);
+		}
+
+		return this;
+	}
+}


### PR DESCRIPTION
Makes it obvious that users can choose to delete the bot's message about removing playground links if there is other text in the message.