### PR TITLE
Fix: update correct status embed when fetching too

### DIFF
--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -352,8 +352,8 @@ export class HelpChanModule extends Module {
 				this.DORMANT_EMBED.title,
 			].includes(embed.title);
 
-		// The message cache does not have a stable order (at least with respect
-		// to creation date), so sorting is needed to find the latest embed.
+		// The message cache/fetch does not have a stable order (at least w.r.t.
+		// creation date), so sorting is needed to find the latest embed.
 		let lastMessage = channel.messages.cache
 			.array()
 			.filter(m => m.author.id === this.client.user?.id)
@@ -361,10 +361,10 @@ export class HelpChanModule extends Module {
 			.find(m => m.embeds.some(isStatusEmbed));
 
 		if (!lastMessage)
-			// Fetch has a stable order, with recent messages first
 			lastMessage = (await channel.messages.fetch({ limit: 5 }))
 				.array()
 				.filter(m => m.author.id === this.client.user?.id)
+				.sort((m1, m2) => m2.createdTimestamp - m1.createdTimestamp)
 				.find(m => m.embeds.some(isStatusEmbed));
 
 		if (lastMessage) {


### PR DESCRIPTION
Like commit 7a617bf15a6b09520df6838d7af534845bfc9d45, but apparently fetching new messages isn't stable after all. There's a maximum of five messages in this queue, so performance should be a non-issue.

I didn't test this, so I'm not 100% sure that it will work; I'm just guessing a little bit at the cause. But lacking the ability to add debug logs to the prod bot, it's my best guess as to why the wrong message was edited here: https://discord.com/channels/508357248330760243/775678879666405427/822791268522000394