### PR TITLE
Update occupied embed bullet points

### DIFF
--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -54,8 +54,9 @@ It is dedicated to answering their questions only. More info: <#${askHelpChannel
 **${asker} You'll get better and faster answers if you:**
 • Describe the context. What are you trying to accomplish?
 • Include any error messages, and the code that produce them (5-15 lines).
-• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
+⠀• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
 • Also reproduce the issue in the **[TypeScript Playground](https://www.typescriptlang.org/play)**, if possible.
+⠀• Do not use a link shortener; paste the full url in its own message.
 
 Usually someone will try to answer and help solve the issue within a few hours. If not, and you have followed the bullets above, you may ping the <@&${trustedRoleId}> role.
 


### PR DESCRIPTION
- Use the same "braille space" trick to indent the code block bullet
- Add a new bullet saying not to use url shorteners for playground links

Result:

![image](https://user-images.githubusercontent.com/6563664/112331599-f5beff80-8cb0-11eb-80c7-0263e0e82bdd.png)

I considered having the second part of the link shortener message say that there's one built in, rather than the own message part, but I figure that will be obvious as soon as someone pastes a link, while the fact that you can put it in its own message (instead of editing your message after the bot has created the embed) is less obvious.