### PR TITLE
Fix: Don't crash if a message has no author

### DIFF
--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -356,7 +356,7 @@ export class HelpChanModule extends Module {
 		// to creation date), so sorting is needed to find the latest embed.
 		let lastMessage = channel.messages.cache
 			.array()
-			.filter(m => m.author.id === this.client.user?.id)
+			.filter(m => m.author && m.author.id === this.client.user?.id)
 			.sort((m1, m2) => m2.createdTimestamp - m1.createdTimestamp)
 			.find(m => m.embeds.some(isStatusEmbed));
 
@@ -364,7 +364,7 @@ export class HelpChanModule extends Module {
 			// Fetch has a stable order, with recent messages first
 			lastMessage = (await channel.messages.fetch({ limit: 5 }))
 				.array()
-				.filter(m => m.author.id === this.client.user?.id)
+				.filter(m => m.author && m.author.id === this.client.user?.id)
 				.find(m => m.embeds.some(isStatusEmbed));
 
 		if (lastMessage) {


### PR DESCRIPTION
When setting the status message, the bot looks for the prior message, to update it if it is found. To do this, it filters the message list by author id. However, sometimes a message does not have an author (unsure when; maybe when the author has left the server?), and the bot crashes.

This slipped by for a long time because the types don't mark the author as nullable (although the api reference does).

Honestly I'm a bit surprised it didn't happen before now, since #117 didn't change this `filter`