### PR TITLE
Fix truncation in 'Misc' !help generation

### DIFF
--- a/src/modules/help.ts
+++ b/src/modules/help.ts
@@ -13,16 +13,10 @@ function getCategoryHelp(cat: string, commands: Set<Command>) {
 	const out: string[] = [];
 
 	for (const cmd of commands) {
-		if (
-			cmd.description &&
-			splitCategoryDescription(cmd.description)[0] === cat
-		) {
-			out.push(
-				`\`${cmd.triggers[0]}\` ► ${cmd.description.substr(
-					cat.length + 2,
-				)}`,
-			);
-		}
+		if (!cmd.description) continue;
+		const [cat2, description] = splitCategoryDescription(cmd.description);
+		if (cat !== cat2) continue;
+		out.push(`\`${cmd.triggers[0]}\` ► ${description}`);
 	}
 
 	return out.join('\n');


### PR DESCRIPTION
Before:
> #### Misc Commands:
> `ping` ► the bot is alive
> `ask` ► a link to [dontasktoask.com](https://dontasktoask.com)
> `reactfc` ► a link to [a pull request removing React.FC](https://github.com/facebook/create-react-app/pull/8177#issue-353062710)
> `playground` ► n a TypeScript playground link
> `help` ► what you're looking at right now

Now:
> #### Misc Commands:
> `ping` ► See if the bot is alive
> `ask` ► Sends a link to [dontasktoask.com](https://dontasktoask.com)
> `reactfc` ► Sends a link to [a pull request removing React.FC](https://github.com/facebook/create-react-app/pull/8177#issue-353062710)
> `playground` ► Shorten a TypeScript playground link
> `help` ► Sends what you're looking at right now