### PR TITLE
Move twoslasher onto a child process

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"husky": "^4.2.5",
 		"prettier": "^2.0.5",
 		"pretty-quick": "^2.0.1",
-		"ts-node-dev": "^1.0.0-pre.60",
+		"ts-node-dev": "^1.1.6",
 		"typescript": "^4.1.3"
 	},
 	"husky": {

--- a/src/modules/twoslash.ts
+++ b/src/modules/twoslash.ts
@@ -1,6 +1,6 @@
 import { command, Module, listener } from 'cookiecord';
 import { Message, TextChannel } from 'discord.js';
-import { twoslasher } from '@typescript/twoslash';
+import { twoslasher } from '../util/twoslasher';
 import { findCodeFromChannel } from '../util/findCodeblockFromChannel';
 import { sendWithMessageOwnership } from '../util/send';
 
@@ -46,7 +46,7 @@ export class TwoslashModule extends Module {
 
 		const symbols = [...new Set(content.trim().split(/\s+/g))];
 
-		const ret = twoslasher(redactNoErrorTruncation(code), 'ts', {
+		const ret = await twoslasher(redactNoErrorTruncation(code), 'ts', {
 			defaultOptions: { noErrorValidation: true },
 		});
 
@@ -93,7 +93,7 @@ export class TwoslashModule extends Module {
 	}
 
 	private async twoslashBlock(msg: Message, code: string) {
-		const ret = twoslasher(redactNoErrorTruncation(code), 'ts', {
+		const ret = await twoslasher(redactNoErrorTruncation(code), 'ts', {
 			defaultOptions: {
 				noErrorValidation: true,
 				noStaticSemanticInfo: false,

--- a/src/util/twoslasher.ts
+++ b/src/util/twoslasher.ts
@@ -1,0 +1,31 @@
+import { fork } from 'child_process';
+import {
+	TwoSlashReturn,
+	twoslasher as _twoslasher,
+} from '@typescript/twoslash';
+
+const childProcess = fork(require.resolve('./twoslasherWorker'));
+
+const resolveMap = new Map<
+	number,
+	[(value: TwoSlashReturn) => void, (value: any) => void]
+>();
+
+childProcess.on('message', message => {
+	if (!(message instanceof Array)) return;
+	const [id, error, value] = message as [number, any, TwoSlashReturn | null];
+	const [resolve, reject] = resolveMap.get(id) ?? [undefined, undefined];
+	if (!resolve || !reject) throw new Error(`Missing id ${id}`);
+	if (error || !value) reject(error);
+	else resolve(value);
+	resolveMap.delete(id);
+});
+
+let idN = 0;
+
+export const twoslasher = (...args: Parameters<typeof _twoslasher>) =>
+	new Promise<TwoSlashReturn>((resolve, reject) => {
+		const id = idN++;
+		resolveMap.set(id, [resolve, reject]);
+		childProcess.send([id, ...args]);
+	});

--- a/src/util/twoslasherWorker.ts
+++ b/src/util/twoslasherWorker.ts
@@ -1,0 +1,11 @@
+import { twoslasher } from '@typescript/twoslash';
+
+process.on('message', message => {
+	const [id, ...args] = message as [number, ...Parameters<typeof twoslasher>];
+	try {
+		const result = twoslasher(...args);
+		process.send!([id, null, result]);
+	} catch (e) {
+		process.send!([id, e, null]);
+	}
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,10 +331,10 @@ chokidar@^3.3.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
-chokidar@^3.4.0:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
-  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+chokidar@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -342,9 +342,9 @@ chokidar@^3.4.0:
     is-binary-path "~2.1.0"
     is-glob "~4.0.1"
     normalize-path "~3.0.0"
-    readdirp "~3.4.0"
+    readdirp "~3.5.0"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -443,6 +443,11 @@ cosmiconfig@^6.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.7.2"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.0:
   version "7.0.3"
@@ -632,6 +637,11 @@ fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 get-caller-file@^2.0.1:
   version "2.0.5"
@@ -1331,6 +1341,13 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -1624,12 +1641,12 @@ trim-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
-ts-node-dev@^1.0.0-pre.60:
-  version "1.0.0-pre.60"
-  resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.0.0-pre.60.tgz#428b051264d9b2b3e58a8a4a02a5d36692436e20"
-  integrity sha512-S1X/2dMH2cxzFEiOWo5r/DTD0oElKbEpG8lnWoEA1LrwxXMFCJs71vIMaXPu6p8ud3MHMI2Ans3syDQ8mkjEUg==
+ts-node-dev@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/ts-node-dev/-/ts-node-dev-1.1.6.tgz#ee2113718cb5a92c1c8f4229123ad6afbeba01f8"
+  integrity sha512-RTUi7mHMNQospArGz07KiraQcdgUVNXKsgO2HAi7FoiyPMdTDqdniB6K1dqyaIxT7c9v/VpSbfBZPS6uVpaFLQ==
   dependencies:
-    chokidar "^3.4.0"
+    chokidar "^3.5.1"
     dateformat "~1.0.4-1.2.3"
     dynamic-dedupe "^0.3.0"
     minimist "^1.2.5"
@@ -1638,15 +1655,16 @@ ts-node-dev@^1.0.0-pre.60:
     rimraf "^2.6.1"
     source-map-support "^0.5.12"
     tree-kill "^1.2.2"
-    ts-node "^8.10.2"
+    ts-node "^9.0.0"
     tsconfig "^7.0.0"
 
-ts-node@^8.10.2:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
+ts-node@^9.0.0:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
   dependencies:
     arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.17"


### PR DESCRIPTION
`!ts` can be rather slow; this moves the `twoslasher` function onto a child process so that the main functions of the bot continue to work while twoslash is doing its thing.

I had to update `ts-node-dev` as the old version had a bug wrt `child_process.fork`.