### PR TITLE
Helpchan: Add closed status

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -40,5 +40,7 @@ export const TS_BLUE = '#007ACC';
 export const GREEN = '#77b155';
 // Picked from Discord's "hourglass" emoji (in ⌛ | Occupied Help Channels)
 export const HOURGLASS_ORANGE = '#ffa647';
+// Picked from Discord's :ballot_box_with_check: emoji (☑)
+export const BALLOT_BOX_BLUE = '#066696';
 // Picked from Discord's blockquote line
 export const BLOCKQUOTE_GREY = '#4f545c';

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -310,10 +310,11 @@ export class HelpChanModule extends Module {
 			);
 			if (dormant && dormant instanceof TextChannel) {
 				await this.moveChannel(dormant, categories.ask);
-				const msg = await this.updateStatusEmbed(
-					dormant,
-					this.AVAILABLE_EMBED,
-				);
+				const msg =
+					(await this.updateStatusEmbed(
+						dormant,
+						this.AVAILABLE_EMBED,
+					)) ?? (await dormant.send(this.AVAILABLE_EMBED));
 				// Temporary -- on first deploy, old statuses won't be pinned,
 				// so the update will create a new one instead; pin it!
 				if (!msg.pinned) await msg.pin();
@@ -415,9 +416,7 @@ export class HelpChanModule extends Module {
 			.find(m => m.embeds.some(isStatusEmbed));
 
 		// If there is a last status message, edit it. Otherwise, send a new message.
-		return lastMessage
-			? await lastMessage.edit(embed)
-			: await channel.send(embed);
+		return await lastMessage?.edit(embed);
 	}
 
 	private async addCooldown(member: GuildMember, channel: TextChannel) {

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -323,7 +323,7 @@ export class HelpChanModule extends Module {
 					this.getChannelName(guild),
 					{
 						type: 'text',
-						topic: 'Ask your questions here!',
+						topic: `One person may ask questions at a time. The current status is pinned. Details: <#${askHelpChannelId}>`,
 						reason: 'maintain help channel goal',
 						parent: categories.ask,
 					},

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -32,10 +32,12 @@ import {
 } from '../env';
 import { isTrustedMember } from '../util/inhibitors';
 
-// The indents are made with a braille pattern blank unicode character, since
-// leading whitespace is stripped. https://www.compart.com/en/unicode/U+2800
-// This is a hack, but it works even on a system without the fonts to display
-// Discord emoji, so it should work everywhere.
+// Embeds trim empty lines, and each line trims whitespace. However, sometimes
+// we want those (e.g. to indent) => A braille pattern blank won't be trimmed.
+// This is a hack, but it should work everywhere; it was tested on a system
+// without even the fonts to display regular Discord emoji.
+const u2800 = '⠀'; // https://www.compart.com/en/unicode/U+2800
+
 const AVAILABLE_MESSAGE = `
 Each help channel is reserved for one person at a time. See <#${askHelpChannelId}>
 **Nobody is using this channel. Send your question here to reserve it.**
@@ -43,11 +45,11 @@ It's always ok to just ask your question; you don't need permission.
 
 **For better & faster answers:**
 • Explain what you want to happen and why…
-⠀• …and what actually happens, and your best guess at why.
+${u2800}• …and what actually happens, and your best guess at why.
 • Include a short code sample and error messages, if you got any.
-⠀• Text is better than screenshots. Start code blocks with ${'```ts'}.
+${u2800}• Text is better than screenshots. Start code blocks with ${'```ts'}.
 • If possible, create a minimal reproduction in the **[TypeScript Playground](https://www.typescriptlang.org/play)**.
-⠀• Send the full link in its own message. Do not use a link shortener.
+${u2800}• Send the full link in its own message. Do not use a link shortener.
 
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
 `;
@@ -59,11 +61,11 @@ If you want help, please ask in an available channel instead.
 
 **For better & faster answers:**
 • Explain what you want to happen and why…
-⠀• …and what actually happens, and your best guess at why.
+${u2800}• …and what actually happens, and your best guess at why.
 • Include a short code sample and error messages, if you got any.
-⠀• Text is better than screenshots. Start code blocks with ${'```ts'}.
+${u2800}• Text is better than screenshots. Start code blocks with ${'```ts'}.
 • If possible, create a minimal reproduction in the **[TypeScript Playground](https://www.typescriptlang.org/play)**.
-⠀• Send the full link in its own message. Do not use a link shortener.
+${u2800}• Send the full link in its own message. Do not use a link shortener.
 
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
 

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -37,45 +37,37 @@ import { isTrustedMember } from '../util/inhibitors';
 // This is a hack, but it works even on a system without the fonts to display
 // Discord emoji, so it should work everywhere.
 const AVAILABLE_MESSAGE = `
-Each help channel is dedicated to helping one person at a time. Details: <#${askHelpChannelId}>
-
-**Send your question here to reserve this channel.**
+Each help channel is reserved for one person at a time. See <#${askHelpChannelId}>
+**Nobody is using this channel. Send your question here to reserve it.**
 It's always ok to just ask your question; you don't need permission.
 
-**Please help others help you:** for better and faster answers…
-• Describe the broader context. What are you trying to accomplish and why?
-• Include what you tried (5-15 lines) and any error messages. Say which line they're on.
-⠀• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
-• Reproduce the issue in the **[TypeScript Playground](https://www.typescriptlang.org/play)**, if possible.
-⠀• Paste the full link in its own message. Do not use a link shortener.
+**For better & faster answers:**
+• Explain what you want to happen and why…
+⠀• …and what actually happens, and your best guess at why.
+• Include a short code sample and error messages, if you got any.
+⠀• Text is better than screenshots. Start code blocks with ${'```ts'}.
+• If possible, create a minimal reproduction in the **[TypeScript Playground](https://www.typescriptlang.org/play)**.
+⠀• Send the full link in its own message. Do not use a link shortener.
 
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
 `;
 
 const occupiedMessage = (asker: GuildMember) => `
-Each help channel is dedicated to helping one person at a time. Details: <#${askHelpChannelId}>
+Each help channel is reserved for one person at a time. See <#${askHelpChannelId}>
+**${asker} is using this channel. Please try to help them, if you can!**
+If you want help, please ask in an available channel instead.
 
-**This channel is reserved by ${asker}.**
-Please help answer their questions, if you can. Thanks!
-
-**${asker} Please help others help you:** For better and faster answers…
-• Describe the broader context. What are you trying to accomplish and why?
-• Include what you tried (5-15 lines) and any error messages. Say which line they're on.
-⠀• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
-• Reproduce the issue in the **[TypeScript Playground](https://www.typescriptlang.org/play)**, if possible.
-⠀• Paste the full link in its own message. Do not use a link shortener.
+**For better & faster answers:**
+• Explain what you want to happen and why…
+⠀• …and what actually happens, and your best guess at why.
+• Include a short code sample and error messages, if you got any.
+⠀• Text is better than screenshots. Start code blocks with ${'```ts'}.
+• If possible, create a minimal reproduction in the **[TypeScript Playground](https://www.typescriptlang.org/play)**.
+⠀• Send the full link in its own message. Do not use a link shortener.
 
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
 
-Usually someone will try to answer and help solve the issue within a few hours. If not, and **if you have followed the bullets above**, you may ping the <@&${trustedRoleId}> role (please allow extra time at night in America/Europe).
-`;
-
-const closedMessage = (next: Message, asker?: GuildMember) => `
-Each help channel is dedicated to helping one person at a time. Details: <#${askHelpChannelId}>
-
-This channel is no longer reserved for ${asker ?? '<User not found>'}.
-
-[Jump to the next question](${next.url})
+Usually someone will try to answer and help solve the issue within a few hours. If not, and **if you have followed the bullets above**, you may ping the <@&${trustedRoleId}> role. Please allow extra time at night in America/Europe.
 `;
 
 const DORMANT_MESSAGE = `
@@ -121,9 +113,9 @@ export class HelpChanModule extends Module {
 		.setTitle('☑ Question Closed')
 		.setColor(BALLOT_BOX_BLUE);
 
-	closedEmbed(next: Message, asker?: GuildMember) {
+	closedEmbed(next: Message) {
 		return new MessageEmbed(this.CLOSED_EMBED_BASE).setDescription(
-			closedMessage(next, asker),
+			`[Jump to the next question](${next.url})`,
 		);
 	}
 
@@ -370,7 +362,7 @@ export class HelpChanModule extends Module {
 			Promise.all<unknown>([
 				this.updateStatusEmbed(
 					channel,
-					this.closedEmbed(newStatus, member),
+					this.closedEmbed(newStatus),
 					pinned.array(),
 				),
 				...pinned

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -12,7 +12,6 @@ import {
 	Guild,
 	TextChannel,
 	GuildMember,
-	User,
 	ChannelData,
 	CategoryChannel,
 } from 'discord.js';
@@ -52,7 +51,7 @@ It's always ok to just ask your question; you don't need permission.
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
 `;
 
-const occupiedMessage = (asker: User) => `
+const occupiedMessage = (asker: GuildMember) => `
 Each help channel is dedicated to helping one person at a time. Details: <#${askHelpChannelId}>
 
 **This channel is reserved by ${asker}.**
@@ -97,13 +96,15 @@ export class HelpChanModule extends Module {
 		.setTitle('⌛ Occupied Help Channel')
 		.setColor(HOURGLASS_ORANGE);
 
-	occupiedEmbed(asker: User) {
+	occupiedEmbed(asker: GuildMember) {
 		return new MessageEmbed(this.OCCUPIED_EMBED_BASE)
 			.setDescription(occupiedMessage(asker))
 			.setFooter(
 				`Closes after ${
 					dormantChannelTimeout / 60 / 60 / 1000
-				} hours of inactivity or when ${asker.username} sends !close.`,
+				} hours of inactivity or when ${
+					asker.displayName
+				} sends !close.`,
 			);
 	}
 
@@ -225,7 +226,7 @@ export class HelpChanModule extends Module {
 
 		this.busyChannels.add(msg.channel.id);
 
-		let embed = this.occupiedEmbed(msg.author);
+		let embed = this.occupiedEmbed(msg.member);
 
 		await this.updateStatusEmbed(msg.channel, embed);
 		await msg.pin();
@@ -484,7 +485,7 @@ export class HelpChanModule extends Module {
 		);
 
 		await toPin.pin();
-		const occupied = this.occupiedEmbed(member.user);
+		const occupied = this.occupiedEmbed(member);
 		await this.updateStatusEmbed(claimedChannel, occupied);
 		await this.addCooldown(member, claimedChannel);
 		await this.moveChannel(claimedChannel, categories.ongoing);

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -244,6 +244,7 @@ export class HelpChanModule extends Module {
 		await this.updateStatusEmbed(msg.channel, occupied);
 		await this.addCooldown(msg.member, msg.channel);
 		await this.moveChannel(msg.channel, categories.ongoing);
+		await msg.pin();
 		await this.ensureAskChannels(msg.guild);
 
 		this.busyChannels.delete(msg.channel.id);
@@ -509,7 +510,7 @@ export class HelpChanModule extends Module {
 
 		this.busyChannels.add(claimedChannel.id);
 
-		await claimedChannel.send(
+		const newMsg = await claimedChannel.send(
 			new MessageEmbed()
 				.setAuthor(member.displayName, member.user.displayAvatarURL())
 				.setDescription(msgContent),
@@ -518,6 +519,7 @@ export class HelpChanModule extends Module {
 		await this.updateStatusEmbed(claimedChannel, occupied);
 		await this.addCooldown(member, claimedChannel);
 		await this.moveChannel(claimedChannel, categories.ongoing);
+		await newMsg.pin();
 		await claimedChannel.send(
 			`${member.user} this channel has been claimed for your question. Please review <#${askHelpChannelId}> for how to get help.`,
 		);

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -115,7 +115,9 @@ export class HelpChanModule extends Module {
 	occupiedEmbed(asker: GuildMember) {
 		return new MessageEmbed(this.OCCUPIED_EMBED_BASE)
 			.setDescription(occupiedMessage(asker))
-			.setFooter(`Closes after ${dormantChannelTimeoutHours} hours of inactivity or when ${asker.username} sends !close.`);
+			.setFooter(
+				`Closes after ${dormantChannelTimeoutHours} hours of inactivity or when ${asker} sends !close.`,
+			);
 	}
 
 	CLOSED_EMBED_BASE = new MessageEmbed()

--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -32,36 +32,42 @@ import {
 } from '../env';
 import { isTrustedMember } from '../util/inhibitors';
 
+// The indents are made with a braille pattern blank unicode character, since
+// leading whitespace is stripped. https://www.compart.com/en/unicode/U+2800
+// This is a hack, but it works even on a system without the fonts to display
+// Discord emoji, so it should work everywhere.
 const AVAILABLE_MESSAGE = `
-**Send your question here to claim the channel**
-This channel will be dedicated to answering your question only. Others will try to answer and help you solve the issue.
+Each help channel is dedicated to helping one person at a time. Details: <#${askHelpChannelId}>
 
-**Keep in mind:**
-• It's always ok to just ask your question. You don't need permission.
-• Explain what you expect to happen and what actually happens.
-• Include a code sample and error message, if you got any.
+**Send your question here to reserve this channel.**
+It's always ok to just ask your question; you don't need permission.
+
+**Please help others help you:** for better and faster answers…
+• Describe the broader context. What are you trying to accomplish and why?
+• Include what you tried (5-15 lines) and any error messages. Say which line they're on.
+⠀• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
+• Reproduce the issue in the **[TypeScript Playground](https://www.typescriptlang.org/play)**, if possible.
+⠀• Paste the full link in its own message. Do not use a link shortener.
 
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
 `;
 
-// The "empty" line has a braille pattern blank unicode character, in order to
-// achieve a leading newline, since normally whitespace is stripped. This is a
-// hack, but it works even on a system without the fonts to display Discord
-// emoji, so it should work everywhere. https://www.compart.com/en/unicode/U+2800
 const occupiedMessage = (asker: User) => `
-⠀
-**This channel is claimed by ${asker}.**
-It is dedicated to answering their questions only. More info: <#${askHelpChannelId}>
+Each help channel is dedicated to helping one person at a time. Details: <#${askHelpChannelId}>
 
-**${asker} You'll get better and faster answers if you:**
-• Describe the context. What are you trying to accomplish?
-• Include any error messages, and the code that produce them (5-15 lines).
-• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
-• Also reproduce the issue in the **[TypeScript Playground](https://www.typescriptlang.org/play)**, if possible.
+**This channel is reserved by ${asker}.**
+Please help answer their questions, if you can. Thanks!
 
-Usually someone will try to answer and help solve the issue within a few hours. If not, and you have followed the bullets above, you may ping the <@&${trustedRoleId}> role.
+**${asker} Please help others help you:** For better and faster answers…
+• Describe the broader context. What are you trying to accomplish and why?
+• Include what you tried (5-15 lines) and any error messages. Say which line they're on.
+⠀• Use code blocks, not screenshots. Start with ${'```ts'} for syntax highlighting.
+• Reproduce the issue in the **[TypeScript Playground](https://www.typescriptlang.org/play)**, if possible.
+⠀• Paste the full link in its own message. Do not use a link shortener.
 
 For more tips, check out StackOverflow's guide on **[asking good questions](https://stackoverflow.com/help/how-to-ask)**.
+
+Usually someone will try to answer and help solve the issue within a few hours. If not, and **if you have followed the bullets above**, you may ping the <@&${trustedRoleId}> role (please allow extra time at night in America/Europe).
 `;
 
 const DORMANT_MESSAGE = `


### PR DESCRIPTION
- Pins the current status, which has more information, instead of the asker's first message.
- When a channel is closed, updates the "ongoing" status embed to "closed" with a link to the next question, useful for skimming.
    - Possible because the status message is pinned now, so we don't have to fetch an arbitrary number of messages to find it.
- For newly-created help channels, make the topic refer to #how-to-get-help and the pinned status instead of "Ask your questions here!"
    - For existing help channels, the topic will need to be updated manually.