### PR TITLE
Fix asker mention in occupied embed footer

### DIFF
--- a/src/modules/helpchan.ts
+++ b/src/modules/helpchan.ts
@@ -116,7 +116,7 @@ export class HelpChanModule extends Module {
 		return new MessageEmbed(this.OCCUPIED_EMBED_BASE)
 			.setDescription(occupiedMessage(asker))
 			.setFooter(
-				`Closes after ${dormantChannelTimeoutHours} hours of inactivity or when ${asker} sends !close.`,
+				`Closes after ${dormantChannelTimeoutHours} hours of inactivity or when ${asker.displayName} sends !close.`,
 			);
 	}
 


### PR DESCRIPTION
Mentions don't render in footers: 
![image](https://user-images.githubusercontent.com/44031566/114446710-65c0f700-9b86-11eb-9b84-18c535ecd0b9.png)

Looking through the blame, this is how it used to be; I'm not sure why it was changed.
