### PR TITLE
Fix bug in findCodeInMessage re pg links

### DIFF
--- a/src/util/codeBlocks.ts
+++ b/src/util/codeBlocks.ts
@@ -40,7 +40,7 @@ function findCodeInMessage(
 		}
 	}
 
-	if (!ignoreLinks) return;
+	if (ignoreLinks) return;
 
 	const match = content.match(PLAYGROUND_REGEX);
 	if (match) {


### PR DESCRIPTION
Apparently I don't know how booleans work