### PR TITLE
fix: add % to playground link regex to allow url-encoded characters

### DIFF
--- a/src/util/codeBlocks.ts
+++ b/src/util/codeBlocks.ts
@@ -4,7 +4,7 @@ import { getReferencedMessage } from './getReferencedMessage';
 
 const CODEBLOCK_REGEX = /```(?:ts|typescript)?\n([\s\S]+)```/;
 
-export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]+)?(?:\&\w+=[^\s#&]+)*)#code\/([\w\-+_]+={0,4})/;
+export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]+)?(?:\&\w+=[^\s#&]+)*)#code\/([\w\-%+_]+={0,4})/;
 
 export async function findCode(message: Message, ignoreLinks = false) {
 	const codeInMessage = findCodeInMessage(message, ignoreLinks);


### PR DESCRIPTION
The other day someone tried to post a playground link that had `%20` in place of `+` - not sure how they got the url formatted that way, but it's a valid url, so I guess we should tweak the regex to support it.