### PR TITLE
fix: bot message clears after editing playground link out of message

### DIFF
--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -101,7 +101,10 @@ export class PlaygroundModule extends Module {
 		const exec = PLAYGROUND_REGEX.exec(msg.content);
 		if (msg.author.bot || !this.editedLongLink.has(msg.id) || exec) return;
 		const botMsg = this.editedLongLink.get(msg.id);
-		await botMsg?.edit('');
+		// Edit the message to only have the embed and not the "please edit your message" message
+		await botMsg?.edit('', {
+			embed: botMsg.embeds[0],
+		});
 		this.editedLongLink.delete(msg.id);
 	}
 }


### PR DESCRIPTION
When you include a playground link in a longer message, the bot shortens the link and tells you to edit the link out of your message - if you do so, that message is supposed to go away, but it hasn't been recently.

There error was:
```ts
await botMsg?.edit('');
```

This errors with a Discord Error about not being able to send empty messages - but if we explicitly include the embed again, it's okay.  