### PR TITLE
fix: detect slash in [FOR HIRE]

### DIFF
--- a/src/modules/mod.ts
+++ b/src/modules/mod.ts
@@ -5,7 +5,7 @@ import { rulesChannelId } from '../env';
 // Most job posts are in this format:
 // > [FOR HIRE][REMOTE][SOMETHING ELSE]
 // > Hi, I'm ponyman6000. Hire me!
-const jobPostRegex = /^(?:\[[A-Z ]+\]\s*){2,}\n/i;
+const jobPostRegex = /^(?:\[[A-Z /]+\]\s*){2,}\n/i;
 
 const SPAM_CHANNEL_THRESHOLD = 3;
 const SPAM_MAX_TIME = 5000;

--- a/src/modules/mod.ts
+++ b/src/modules/mod.ts
@@ -5,7 +5,7 @@ import { rulesChannelId } from '../env';
 // Most job posts are in this format:
 // > [FOR HIRE][REMOTE][SOMETHING ELSE]
 // > Hi, I'm ponyman6000. Hire me!
-const jobPostRegex = /^(?:\[[A-Z /]+\]\s*){2,}\n/i;
+const jobPostRegex = /^(?:\[[A-Z /-]+\]\s*){2,}\n/i;
 
 const SPAM_CHANNEL_THRESHOLD = 3;
 const SPAM_MAX_TIME = 5000;


### PR DESCRIPTION
It seems to become very common for job posts to contain a slash, e.g.: `[For Hire][Full Time/Part Time]` `[FOR HIRE][REMOTE][FrontEnd/BlockChain]` (verbatim copy from two messages still in the server).