### PR TITLE
fix: allow playground regex to contain query with no value

### DIFF
--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -201,7 +201,7 @@ function getSelectionQueryParams(query: string, numLines: number) {
 	const [startLine, endLine] = ['pln', 'ssl']
 		// @ts-expect-error parseInt(null) is okay here since we check for NaN
 		.map(name => parseInt(params.get(name)))
-		.map(n => (n !== NaN && 1 <= n && n <= numLines ? n : undefined))
+		.map(n => (!Number.isNaN(n) && 1 <= n && n <= numLines ? n : undefined))
 		.sort((a, b) => (a ?? Infinity) - (b ?? Infinity));
 
 	return { startLine, endLine };

--- a/src/util/codeBlocks.ts
+++ b/src/util/codeBlocks.ts
@@ -4,7 +4,7 @@ import { getReferencedMessage } from './getReferencedMessage';
 
 const CODEBLOCK_REGEX = /```(?:ts|typescript)?\n([\s\S]+)```/;
 
-export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]+)?(?:\&\w+=[^\s#&]+)*)#code\/([\w\-%+_]+={0,4})/;
+export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4})/;
 
 export async function findCode(message: Message, ignoreLinks = false) {
 	const codeInMessage = findCodeInMessage(message, ignoreLinks);


### PR DESCRIPTION
This is a valid playground link that I hit upon: `https://www.typescriptlang.org/play?lib=lib.dom.d.ts&ts=#code/PTAEAEBsEsCMC5QBMD2BbAsAKAMYoHYDOALqAIagC8oAjANzZA`

The `ts=` fails to be matched.