### PR TITLE
Allow an optional language code in playground URLs

### DIFF
--- a/src/util/codeBlocks.ts
+++ b/src/util/codeBlocks.ts
@@ -4,7 +4,7 @@ import { getReferencedMessage } from './getReferencedMessage';
 
 const CODEBLOCK_REGEX = /```(?:ts|typescript|js|javascript)?\n([\s\S]+)```/;
 
-export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4})/;
+export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:[a-z]{2,3}\/)?(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4})/;
 
 export async function findCode(message: Message, ignoreLinks = false) {
 	const codeInMessage = await findCodeInMessage(message, ignoreLinks);


### PR DESCRIPTION
I'm not entirely sure about the structure of such URLs, but tried a few things and noticed that things like [`/es/`](https://www.typescriptlang.org/es/play) and [`/fr/`](https://www.typescriptlang.org/fr/play) work, while [`/en-US/`](https://www.typescriptlang.org/en-US/play) does not, so I'm guessing they're meant to be [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) "primary language subtags" without additional subtags. I could make the regex looser if we want to accept dashes/capital letters/longer language codes/other stuff in this path segment.