### PR TITLE
Fix rep reaction giver

### DIFF
--- a/src/modules/rep.ts
+++ b/src/modules/rep.ts
@@ -114,7 +114,7 @@ export class RepModule extends Module {
 			channel: msg.channelId,
 			amount: 1,
 			recipient,
-			initialGiver: author.id,
+			initialGiver: user.id,
 			date: new Date().toISOString(),
 		}).save();
 


### PR DESCRIPTION
At the moment, when someone reacts with `:rep:` to a message, it sets `initialGiver` to the author of the message, not the author of the reaction, making it seem like the recipient is repping themselves.