### PR TITLE
Don't show a preview for a playground link if wrapped in < >

### DIFF
--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -16,8 +16,8 @@ import { TS_BLUE } from '../env';
 import {
 	makeCodeBlock,
 	findCode,
-	PLAYGROUND_REGEX,
-	truncate,
+	matchPlaygroundLink,
+	PlaygroundLinkMatch,
 } from '../util/codeBlocks';
 import { LimitedSizeMap } from '../util/limitedSizeMap';
 import {
@@ -66,10 +66,10 @@ export class PlaygroundModule extends Module {
 	async onPlaygroundLinkMessage(msg: Message) {
 		if (msg.author.bot) return;
 		if (msg.content[0] === '!') return;
-		const exec = PLAYGROUND_REGEX.exec(msg.content);
+		const exec = matchPlaygroundLink(msg.content);
 		if (!exec) return;
 		const embed = createPlaygroundEmbed(msg.author, exec);
-		if (exec[0] === msg.content && !isHelpChannel(msg.channel)) {
+		if (exec.url === msg.content && !isHelpChannel(msg.channel)) {
 			// Message only contained the link
 			await sendWithMessageOwnership(msg, { embeds: [embed] });
 			await msg.delete();
@@ -90,12 +90,12 @@ export class PlaygroundModule extends Module {
 		const attachment = msg.attachments.find(a => a.name === 'message.txt');
 		if (msg.author.bot || !attachment) return;
 		const content = await fetch(attachment.url).then(r => r.text());
-		const exec = PLAYGROUND_REGEX.exec(content);
+		const exec = matchPlaygroundLink(content);
 		// By default, if you write a message in the box and then paste a long
 		// playground link, it will only put the paste in message.txt and will
 		// put the rest of the message in msg.content
-		if (!exec || exec[0] !== content) return;
-		const shortenedUrl = await shortenPlaygroundLink(exec[0]);
+		if (!exec || exec.url !== content) return;
+		const shortenedUrl = await shortenPlaygroundLink(exec.url);
 		const embed = createPlaygroundEmbed(msg.author, exec, shortenedUrl);
 		await sendWithMessageOwnership(msg, { embeds: [embed] });
 		if (!msg.content) await msg.delete();
@@ -104,7 +104,7 @@ export class PlaygroundModule extends Module {
 	@listener({ event: 'messageUpdate' })
 	async onLongFix(_oldMsg: Message, msg: Message) {
 		if (msg.partial) await msg.fetch();
-		const exec = PLAYGROUND_REGEX.exec(msg.content);
+		const exec = matchPlaygroundLink(msg.content);
 		if (msg.author.bot || !this.editedLongLink.has(msg.id) || exec) return;
 		const botMsg = this.editedLongLink.get(msg.id);
 		// Edit the message to only have the embed and not the "please edit your message" message
@@ -119,7 +119,7 @@ export class PlaygroundModule extends Module {
 // Take care when messing with the truncation, it's extremely finnicky
 function createPlaygroundEmbed(
 	author: User,
-	[_url, query, code]: RegExpExecArray,
+	{ url: _url, query, code }: PlaygroundLinkMatch,
 	url: string = _url,
 ) {
 	const embed = new MessageEmbed()

--- a/src/modules/playground.ts
+++ b/src/modules/playground.ts
@@ -69,9 +69,11 @@ export class PlaygroundModule extends Module {
 		const exec = matchPlaygroundLink(msg.content);
 		if (!exec) return;
 		const embed = createPlaygroundEmbed(msg.author, exec);
-		if (exec.url === msg.content && !isHelpChannel(msg.channel)) {
+		if (exec.isWholeMatch && !isHelpChannel(msg.channel)) {
 			// Message only contained the link
-			await sendWithMessageOwnership(msg, { embeds: [embed] });
+			await sendWithMessageOwnership(msg, {
+				embeds: [embed],
+			});
 			await msg.delete();
 		} else {
 			// Message also contained other characters
@@ -94,10 +96,12 @@ export class PlaygroundModule extends Module {
 		// By default, if you write a message in the box and then paste a long
 		// playground link, it will only put the paste in message.txt and will
 		// put the rest of the message in msg.content
-		if (!exec || exec.url !== content) return;
+		if (!exec?.isWholeMatch) return;
 		const shortenedUrl = await shortenPlaygroundLink(exec.url);
 		const embed = createPlaygroundEmbed(msg.author, exec, shortenedUrl);
-		await sendWithMessageOwnership(msg, { embeds: [embed] });
+		await sendWithMessageOwnership(msg, {
+			embeds: [embed],
+		});
 		if (!msg.content) await msg.delete();
 	}
 
@@ -119,7 +123,7 @@ export class PlaygroundModule extends Module {
 // Take care when messing with the truncation, it's extremely finnicky
 function createPlaygroundEmbed(
 	author: User,
-	{ url: _url, query, code }: PlaygroundLinkMatch,
+	{ url: _url, query, code, isEscaped }: PlaygroundLinkMatch,
 	url: string = _url,
 ) {
 	const embed = new MessageEmbed()
@@ -179,13 +183,16 @@ function createPlaygroundEmbed(
 		formattedSection.replace(/^\s*\n|\n\s*$/g, '') +
 		(prettyEndChar === pretty.length ? '' : '\n...');
 
-	if (!startLine && !endLine) {
-		embed.setFooter(
-			'You can choose specific lines to embed by selecting them before copying the link.',
-		);
+	if (!isEscaped) {
+		embed.setDescription('**Preview:**' + makeCodeBlock(content));
+		if (!startLine && !endLine) {
+			embed.setFooter(
+				'You can choose specific lines to embed by selecting them before copying the link.',
+			);
+		}
 	}
 
-	return embed.setDescription('**Preview:**' + makeCodeBlock(content));
+	return embed;
 }
 
 async function shortenPlaygroundLink(url: string) {

--- a/src/util/codeBlocks.ts
+++ b/src/util/codeBlocks.ts
@@ -4,7 +4,17 @@ import { getReferencedMessage } from './getReferencedMessage';
 
 const CODEBLOCK_REGEX = /```(?:ts|typescript|js|javascript)?\n([\s\S]+)```/;
 
-export const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:[a-z]{2,3}\/)?(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4})/;
+const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:[a-z]{2,3}\/)?(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4})/;
+
+export type PlaygroundLinkMatch = { url: string; query: string; code: string };
+export function matchPlaygroundLink(
+	msg: string,
+): PlaygroundLinkMatch | undefined {
+	const match = msg.match(PLAYGROUND_REGEX);
+	if (!match) return;
+	const [url, query, code] = match;
+	return { url, query, code };
+}
 
 export async function findCode(message: Message, ignoreLinks = false) {
 	const codeInMessage = await findCodeInMessage(message, ignoreLinks);
@@ -43,15 +53,12 @@ async function findCodeInMessage(msg: Message, ignoreLinks = false) {
 
 	if (ignoreLinks) return;
 
-	const match = content.match(PLAYGROUND_REGEX);
-	if (match) {
-		return decompressFromEncodedURIComponent(match[2]);
-	}
+	const codeSources = [content, ...embeds.map(({ url }) => url)];
 
-	for (const embed of embeds) {
-		const match = embed.url?.match(PLAYGROUND_REGEX);
+	for (const code of codeSources) {
+		const match = code && matchPlaygroundLink(code);
 		if (match) {
-			return decompressFromEncodedURIComponent(match[2]);
+			return decompressFromEncodedURIComponent(match.code);
 		}
 	}
 }

--- a/src/util/codeBlocks.ts
+++ b/src/util/codeBlocks.ts
@@ -4,16 +4,25 @@ import { getReferencedMessage } from './getReferencedMessage';
 
 const CODEBLOCK_REGEX = /```(?:ts|typescript|js|javascript)?\n([\s\S]+)```/;
 
-const PLAYGROUND_REGEX = /https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:[a-z]{2,3}\/)?(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4})/;
+const PLAYGROUND_REGEX = /<?(https?:\/\/(?:www\.)?(?:typescriptlang|staging-typescript)\.org\/(?:[a-z]{2,3}\/)?(?:play|dev\/bug-workbench)(?:\/index\.html)?\/?(\??(?:\w+=[^\s#&]*)?(?:\&\w+=[^\s#&]*)*)#code\/([\w\-%+_]+={0,4}))>?/;
 
-export type PlaygroundLinkMatch = { url: string; query: string; code: string };
+export type PlaygroundLinkMatch = {
+	url: string;
+	query: string;
+	code: string;
+	isWholeMatch: boolean;
+	/* Is the url wrapped in < > ? */
+	isEscaped: boolean;
+};
 export function matchPlaygroundLink(
 	msg: string,
 ): PlaygroundLinkMatch | undefined {
 	const match = msg.match(PLAYGROUND_REGEX);
 	if (!match) return;
-	const [url, query, code] = match;
-	return { url, query, code };
+	const [possiblyEscapedUrl, url, query, code] = match;
+	const isWholeMatch = msg === possiblyEscapedUrl;
+	const isEscaped = possiblyEscapedUrl.length === url.length + 2;
+	return { url, query, code, isWholeMatch, isEscaped };
 }
 
 export async function findCode(message: Message, ignoreLinks = false) {


### PR DESCRIPTION
Allow the preview to be suppressed by escaping the url in `<>` - this can be useful if you've already sent the code (or most of it) in a previous message.

Also refactors the regex parsing into a single function, rather than exporting the regex and using it throughout.  Seemed clearer than adding more one-off logic in the places that consume the Regex.