### PR TITLE
Add `!solved` alias to close help posts

### DIFF
--- a/src/modules/helpForum.ts
+++ b/src/modules/helpForum.ts
@@ -189,7 +189,7 @@ export async function helpForumModule(bot: Bot) {
 	});
 
 	bot.registerCommand({
-		aliases: ['resolved', 'resolve', 'close', 'closed', 'done'],
+		aliases: ['resolved', 'resolve', 'close', 'closed', 'done', 'solved'],
 		description: 'Help System: Mark a post as resolved',
 		async listener(msg) {
 			changeStatus(msg, true);


### PR DESCRIPTION
As suggested [here](https://discord.com/channels/508357248330760243/508357683506708514/1139583768487804949).